### PR TITLE
failing config

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -1,5 +1,4 @@
-import { validate } from "@deepkit/type";
-import { User } from "./models";
+import { test } from "./other";
 
-console.log('valid', validate<User>({ id: 0, username: 'Peter' }));
-console.log('invalid', validate<User>({ id: 0, username: 'x' }));
+
+test()

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,7 +21,8 @@ module.exports = {
                         getCustomTransformers: (program, getProgram) => ({
                             before: [typeCompiler.transformer],
                             afterDeclarations: [typeCompiler.declarationTransformer],
-                        })
+                        }),
+                        experimentalWatchApi: true
                     }
                 },
                 exclude: /node_modules/,


### PR DESCRIPTION
enabling `experimentalWatchApi: true` prevents correct compilation of not entry files